### PR TITLE
Fix getMember unit test function name

### DIFF
--- a/test/test_TrelloMember.py
+++ b/test/test_TrelloMember.py
@@ -6,7 +6,7 @@ Function: test_GetMember
 Purpose: This function is meant to be called by pytest and verifies the ability to 
 instantiate a Member object and initializes it from a Trello Member request
 '''
-def test_GetMember():
+def test_getMember():
     member = Member()
     assert member.initialized == True
     assert member.username == 'patrickfreel'


### PR DESCRIPTION
Changed name unit test name
from                to
test_GetMember()    test_getMember()

Changes to be committed:
	modified:   test/test_TrelloMember.py