### PR TITLE
Fix unit test function name for getTrelloRequest

### DIFF
--- a/test/test_TrelloRequest.py
+++ b/test/test_TrelloRequest.py
@@ -1,7 +1,7 @@
 from ..src import TrelloUtilities
 from ..src.TrelloRequest import TrelloRequest
 
-def test_GetTrelloRequest():
+def test_getTrelloRequest():
 
     # create URL
     settings = TrelloUtilities.Settings()


### PR DESCRIPTION
Changed unit test function name

Changes to be committed:
	modified:   test/test_TrelloRequest.py